### PR TITLE
Feature: Changing get_table_names from column_parser

### DIFF
--- a/sqlanalyzer/column_parser.py
+++ b/sqlanalyzer/column_parser.py
@@ -99,7 +99,7 @@ class Parser:
 
         for line in line_query:
             
-            table_line = re.findall(r"(FROM|JOIN).(\w*`?.*)", line)
+            table_line = re.findall(r"(?i)(FROM|JOIN).(\w*`?.*)", line)
 
             if table_line != []:
                 table_name_line = table_line[0][1].split(' ')

--- a/sqlanalyzer/column_parser.py
+++ b/sqlanalyzer/column_parser.py
@@ -99,7 +99,7 @@ class Parser:
 
         for line in line_query:
             
-            table_line = re.findall(r"(FROM|JOIN).(\w+.*)", line)
+            table_line = re.findall(r"(FROM|JOIN).(\w*`?.*)", line)
 
             if table_line != []:
                 table_name_line = table_line[0][1].split(' ')

--- a/sqlanalyzer/tests/test_column_parser.py
+++ b/sqlanalyzer/tests/test_column_parser.py
@@ -22,6 +22,7 @@ def sample_query_diff_dbs():
     """
     return query
 
+
 @pytest.fixture
 def formatter(sample_query):
     formatter = column_parser.Parser(sample_query)
@@ -54,3 +55,5 @@ def test_get_table_names_diff_dbs(sample_query_diff_dbs, formatter):
 
     assert table_name_mapping == {'`some_database.schema.table`': '`some_database.schema.table`',
                                     'some_schema.some_table': 'some_schema.some_table'}
+
+   

--- a/sqlanalyzer/tests/test_column_parser.py
+++ b/sqlanalyzer/tests/test_column_parser.py
@@ -13,6 +13,16 @@ def sample_query():
 
 
 @pytest.fixture
+def sample_query_diff_dbs():
+    query = """
+        SELECT * 
+        from `some_database.schema.table`
+        INNER JOIN some_schema.some_table
+        WHERE column IS NULL
+    """
+    return query
+
+@pytest.fixture
 def formatter(sample_query):
     formatter = column_parser.Parser(sample_query)
     return formatter
@@ -36,3 +46,11 @@ def test_get_table_names(sample_query, formatter):
 
     assert table_name_mapping == {'sfdc_accounts': 'sfdc.accounts',
                                     'opportunity_to_name': 'opportunity_to_name'}
+
+
+def test_get_table_names_diff_dbs(sample_query_diff_dbs, formatter):
+    formatted_query = formatter.format_query(sample_query_diff_dbs)
+    table_name_mapping = formatter.get_table_names(formatted_query.split('\n'))
+
+    assert table_name_mapping == {'`some_database.schema.table`': '`some_database.schema.table`',
+                                    'some_schema.some_table': 'some_schema.some_table'}

--- a/sqlanalyzer/tests/test_column_parser.py
+++ b/sqlanalyzer/tests/test_column_parser.py
@@ -56,4 +56,4 @@ def test_get_table_names_diff_dbs(sample_query_diff_dbs, formatter):
     assert table_name_mapping == {'`some_database.schema.table`': '`some_database.schema.table`',
                                     'some_schema.some_table': 'some_schema.some_table'}
 
-   
+  

--- a/sqlanalyzer/tests/test_column_parser.py
+++ b/sqlanalyzer/tests/test_column_parser.py
@@ -49,7 +49,8 @@ def test_get_table_names(sample_query, formatter):
                                     'opportunity_to_name': 'opportunity_to_name'}
 
 
-def test_get_table_names_diff_dbs(sample_query_diff_dbs, formatter):
+def test_get_table_names_diff_dbs(sample_query_diff_dbs):
+    formatter = column_parser.Parser(sample_query_diff_dbs)
     formatted_query = formatter.format_query(sample_query_diff_dbs)
     table_name_mapping = formatter.get_table_names(formatted_query.split('\n'))
 

--- a/sqlanalyzer/tests/test_column_parser.py
+++ b/sqlanalyzer/tests/test_column_parser.py
@@ -55,5 +55,4 @@ def test_get_table_names_diff_dbs(sample_query_diff_dbs, formatter):
 
     assert table_name_mapping == {'`some_database.schema.table`': '`some_database.schema.table`',
                                     'some_schema.some_table': 'some_schema.some_table'}
-
-  
+   


### PR DESCRIPTION
This pull request adds the capability to the `get_table_names` method to find table names when the backtick (`) character is being used. Additionally, the regular expression has been updated to be case insensitive. These changes are specific to the `get_table_names` method and do not affect the case sensitivity of regex in other methods.